### PR TITLE
+1以外のリアクションでいいね数が正常に減らないバグを修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ app.event('reaction_removed', async ({ event, client }) => {
   const itemTs = i.ts;
   const eventTs = event.event_ts;
 
-  if (event.reaction !== '+1') return; // いいね以外を除外
+  if (event.reaction.indexOf('+1') == -1) return; // いいね以外を除外
   if (itemUserId === reactionUserId) return; // セルフいいねを除外
 
   // Goodreactionsの削除


### PR DESCRIPTION
`reaction_added` では `+1` **を含む**リアクションに反応していたのに対し、 `reaction_removed` では `+1` **と完全に一致する**リアクションに反応しているため、削除処理が正常に行われませんでした。
`reaction_removed` の判断基準を `+1` **を含む**に変更しました。