### PR TITLE
人数が多い時に取得できないバグを修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -338,27 +338,13 @@ app.event('member_joined_channel', async ({ event, client }) => {
     let message = value;
 
     if (value.includes('%JOINNUMBER%')) {
-      let members: string[] = [];
-      let cursor: string | undefined;
+      // チャンネルの情報を取得
+      const info = await client.conversations.info({
+        channel: event.channel,
+      });
 
-      do {
-        // チャンネルのメンバー一覧を取得
-        const result = await client.conversations.members({
-          channel: event.channel,
-          cursor: cursor,
-        });
-
-        // メンバーリストを追加
-        if (result.members) {
-          members = members.concat(result.members);
-        }
-
-        // 次のページがあれば cursor を更新
-        cursor = result.response_metadata?.next_cursor;
-      } while (cursor);
-
-      // 全メンバー数を取得
-      const joinNumber = members.length;
+      // num_members から参加者数を取得
+      const joinNumber = info.channel?.num_members || 0;
 
       message = message.replace(/%JOINNUMBER%/g, joinNumber.toString());
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -338,13 +338,27 @@ app.event('member_joined_channel', async ({ event, client }) => {
     let message = value;
 
     if (value.includes('%JOINNUMBER%')) {
-      // チャンネルのメンバー一覧を取得
-      const result = await client.conversations.members({
-        channel: event.channel,
-      });
+      let members: string[] = [];
+      let cursor: string | undefined;
 
-      // 新たに参加したユーザーも含めたメンバー数を取得
-      const joinNumber = result.members?.length ?? 0;
+      do {
+        // チャンネルのメンバー一覧を取得
+        const result = await client.conversations.members({
+          channel: event.channel,
+          cursor: cursor,
+        });
+
+        // メンバーリストを追加
+        if (result.members) {
+          members = members.concat(result.members);
+        }
+
+        // 次のページがあれば cursor を更新
+        cursor = result.response_metadata?.next_cursor;
+      } while (cursor);
+
+      // 全メンバー数を取得
+      const joinNumber = members.length;
 
       message = message.replace(/%JOINNUMBER%/g, joinNumber.toString());
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,6 +341,7 @@ app.event('member_joined_channel', async ({ event, client }) => {
       // チャンネルの情報を取得
       const info = await client.conversations.info({
         channel: event.channel,
+        include_num_members: true,
       });
 
       // num_members から参加者数を取得


### PR DESCRIPTION
学園 WS でテストしていたところ大人数のチャンネルでは正しく取得できておらず
API などのドキュメントを確認した場合に `response_metadata.next_cursor` を見つけたので
修正したコードです