### PR TITLE
リアクションをくれたユーザーをキリ番メッセージに追加する

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ app.event('reaction_added', async ({ event, client }) => {
   }
 
   console.log(
-    `[${nowStr()}][INFO] Add Goodreaction goodcount: ${goodcount} itemUserId: ${itemUserId} reactionUserId: ${reactionUserId} eventTs: ${eventTs}`,
+    `[${nowStr()}][INFO] Add Goodreaction goodcount: ${goodcount} itemUserId: ${itemUserId} reactionUserId: ${reactionUserId} eventTs: ${eventTs}`
   );
 });
 
@@ -190,7 +190,7 @@ app.event('reaction_removed', async ({ event, client }) => {
   }
 
   console.log(
-    `[${nowStr()}][INFO] Remove Goodreaction goodcount: ${goodcount} itemUserId: ${itemUserId} reactionUserId: ${reactionUserId} eventTs: ${eventTs}`,
+    `[${nowStr()}][INFO] Remove Goodreaction goodcount: ${goodcount} itemUserId: ${itemUserId} reactionUserId: ${reactionUserId} eventTs: ${eventTs}`
   );
 });
 
@@ -205,7 +205,7 @@ function saveJoinMessages() {
   fs.writeFileSync(
     joinMessagesFileName,
     JSON.stringify(Array.from(joinMessages)),
-    'utf8',
+    'utf8'
   );
 }
 
@@ -213,7 +213,7 @@ function saveLeftMessages() {
   fs.writeFileSync(
     leftMessagesFileName,
     JSON.stringify(Array.from(leftMessages)),
-    'utf8',
+    'utf8'
   );
 }
 
@@ -249,11 +249,11 @@ app.message(
       await say(
         `入室メッセージを登録したよ。\n登録された入室メッセージ:\n\n${joinMessage.replace(
           '\\n',
-          '\n',
-        )}`,
+          '\n'
+        )}`
       );
     }
-  },
+  }
 );
 
 // 発言したチャンネルの入室メッセージの設定を解除する
@@ -293,11 +293,11 @@ app.message(
       await say(
         `退出メッセージを登録したよ。\n登録された退出メッセージ:\n\n${leftMessage.replace(
           '\\n',
-          '\n',
-        )}`,
+          '\n'
+        )}`
       );
     }
-  },
+  }
 );
 
 // 発言したチャンネルの入室メッセージの設定を解除する

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ app.event('reaction_added', async ({ event, client }) => {
   if (goodcount === 10 || goodcount === 50 || goodcount % 100 === 0) {
     await client.chat.postMessage({
       channel: i.channel,
-      text: `<@${itemUserId}>ちゃん、すごーい！記念すべき ${goodcount} 回目のいいねだよ！おめでとー！`,
+      text: `<@${itemUserId}>ちゃん、すごーい！ <@${reactionUserId}>が記念すべき ${goodcount} 回目のいいねをくれたよ！おめでとー！`,
     });
   }
 


### PR DESCRIPTION
## Overview

「<@${itemUserId}>ちゃん、すごーい！ <@${reactionUserId}>が記念すべき ${goodcount} 回目のいいねをくれたよ！おめでとー！」のように、リアクションを押してくれた人を明示する。

## Contexts

#11 を参照。

下記のような荒らしが発生しており、当初はクールダウンでの実装を検討していたが、 @n-mache さんの下記コメントにて「クールダウンは複雑すぎる→初心者向けというリポの趣旨から外れる」「リアクションした人を明記するだけでも荒らしをする人は減る」とのご指摘を賜り、修正。
コメントありがとうございました 🙇🏻 

https://github.com/sifue/serval-bolt/pull/11#issuecomment-4060330358

<img width="1210" height="424" alt="image" src="https://github.com/user-attachments/assets/522e63b0-a527-4ccd-bb61-c3fdb08c579c" />
