### PR TITLE
リアクションの付け外しによるいいねカウント操作を防止

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,20 @@ app.event('reaction_added', async ({ event, client }) => {
   if (itemUserId === reactionUserId) return; // セルフいいねを除外
   if (!itemUserId) return; // itemUserIdが空であるパターンを除外
 
+  // 同一ユーザーが同一メッセージに既にリアクション済みならスキップ（リアクションの付け外しによるカウント操作を防止）
+  const existing = await prisma.goodreactions.findUnique({
+    where: {
+      itemUserId_reactionUserId_itemChannel_itmeType_itemTs: {
+        itemUserId,
+        reactionUserId,
+        itemChannel,
+        itmeType,
+        itemTs,
+      },
+    },
+  });
+  if (existing) return;
+
   // Goodreactionsへの保存
   await prisma.goodreactions.create({
     data: {


### PR DESCRIPTION
## Summary

- 同一ユーザーが同一メッセージに対してリアクションを付け外しすることで、キリ番メッセージが繰り返し発火する問題（#11）を修正
- `reaction_added` 時に `Goodreactions` テーブルに既にレコードが存在する場合、カウントのインクリメントをスキップする
- 既存の複合主キー `(itemUserId, reactionUserId, itemChannel, itmeType, itemTs)` を活用した `findUnique` による重複チェック

## 背景

リアクションの付け外しを繰り返すと、カウントが 9→10→9→10... のように振れ、10回目等の記念メッセージが何度も投稿される荒らしが発生していました（#11）。

PR #12 では「リアクションした人を表示する」抑止策が提案されていますが、本PRでは根本原因であるカウント操作自体を技術的に防止します。

## 仕組み

`reaction_added` イベント処理の冒頭で、同一ユーザー・同一メッセージの組み合わせが既に `Goodreactions` に存在するかを確認し、存在すれば早期リターンします。これにより、一度外して再度つけた場合にカウントが二重に加算されることを防ぎます。

## Test plan

- [ ] ユーザーAがメッセージXに 👍 をつける → カウント +1
- [ ] ユーザーAが 👍 を外す → カウント -1
- [ ] ユーザーAが再度 👍 をつける → カウントが増えないことを確認
- [ ] 別のユーザーBが同じメッセージXに 👍 をつける → カウント +1（正常動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)